### PR TITLE
feat: improve playground service architecture

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,8 +14,7 @@ This guide will help you set up and start using the GTM Crawler service.
 1. Clone the repository:
 
 ```bash
-git clone [repository-url]
-cd llm-crawler
+git clone https://github.com/dougwithseismic/gtm-crawler.git
 ```
 
 2. Install dependencies and set up the tunnel:

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -1,0 +1,71 @@
+# Playground Service
+
+The Playground service is a flexible execution environment that allows you to run custom code through a plugin-based architecture while leveraging the same powerful webhook and event system as the crawler service.
+
+## Table of Contents
+
+- [Getting Started](./guides/getting-started.md)
+- [API Reference](./api/README.md)
+- [Plugin System](./plugins/README.md)
+- [Webhook Events](./guides/webhooks.md)
+- [Integration Examples](./examples/README.md)
+
+## Key Features
+
+- **Plugin Architecture**: Extensible system for custom code execution and analysis
+- **Job Management**: Efficient handling of multiple execution jobs
+- **Storage System**: Built-in storage capabilities for plugins
+- **Webhook Integration**: Real-time progress notifications and event tracking
+- **Error Handling**: Comprehensive error tracking and reporting
+- **TypeScript Support**: Full type safety and excellent IDE integration
+
+## Quick Start
+
+```bash
+# Create a new job
+curl -X POST http://localhost:3000/playground/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "data": "your input data here"
+    },
+    "plugins": ["example-plugin"]
+  }'
+
+# Start the job
+curl -X POST http://localhost:3000/playground/jobs/{jobId}/start
+
+# Check job status
+curl http://localhost:3000/playground/jobs/{jobId}
+```
+
+## Project Structure
+
+```
+src/
+├── services/
+│   └── playground/
+│       ├── playground.ts    # Main playground service
+│       ├── plugins/         # Plugin implementations
+│       └── types.ts         # TypeScript type definitions
+└── routes/
+    └── playground.ts        # API endpoints
+```
+
+## Use Cases
+
+The Playground service is ideal for:
+
+1. **Custom Data Processing**: Execute custom data transformation and analysis
+2. **Integration Testing**: Run integration tests with external services
+3. **Workflow Automation**: Create complex automation workflows with n8n or make.com
+4. **Data Enrichment**: Process and enrich data through custom plugins
+5. **Scheduled Tasks**: Execute periodic tasks with webhook notifications
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guide](../guides/contributing.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -1,6 +1,6 @@
 # Playground Service
 
-The Playground service is a flexible execution environment that allows you to run custom code through a plugin-based architecture while leveraging the same powerful webhook and event system as the crawler service.
+The Playground service is a flexible execution environment that allows you to run custom code through a plugin-based architecture with support for both synchronous and asynchronous execution modes.
 
 ## Table of Contents
 
@@ -12,28 +12,48 @@ The Playground service is a flexible execution environment that allows you to ru
 
 ## Key Features
 
+- **Flexible Execution Modes**: Choose between synchronous and asynchronous execution
 - **Plugin Architecture**: Extensible system for custom code execution and analysis
 - **Job Management**: Efficient handling of multiple execution jobs
 - **Storage System**: Built-in storage capabilities for plugins
-- **Webhook Integration**: Real-time progress notifications and event tracking
+- **Real-time Updates**: Comprehensive event system with webhook integration
 - **Error Handling**: Comprehensive error tracking and reporting
 - **TypeScript Support**: Full type safety and excellent IDE integration
 
 ## Quick Start
 
+### Synchronous Execution
+
 ```bash
-# Create a new job
+# Create and execute a job synchronously
 curl -X POST http://localhost:3000/playground/jobs \
   -H "Content-Type: application/json" \
   -d '{
     "input": {
       "data": "your input data here"
     },
-    "plugins": ["example-plugin"]
+    "plugins": ["example-plugin"],
+    "async": false
   }'
+```
 
-# Start the job
-curl -X POST http://localhost:3000/playground/jobs/{jobId}/start
+### Asynchronous Execution
+
+```bash
+# Create and execute a job asynchronously
+curl -X POST http://localhost:3000/playground/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "data": "your input data here"
+    },
+    "plugins": ["example-plugin"],
+    "async": true,
+    "webhook": {
+      "url": "https://your-server.com/webhook",
+      "on": ["completed", "failed"]
+    }
+  }'
 
 # Check job status
 curl http://localhost:3000/playground/jobs/{jobId}
@@ -56,11 +76,45 @@ src/
 
 The Playground service is ideal for:
 
-1. **Custom Data Processing**: Execute custom data transformation and analysis
-2. **Integration Testing**: Run integration tests with external services
-3. **Workflow Automation**: Create complex automation workflows with n8n or make.com
-4. **Data Enrichment**: Process and enrich data through custom plugins
-5. **Scheduled Tasks**: Execute periodic tasks with webhook notifications
+1. **Quick Data Processing**: Use synchronous mode for immediate results
+   - Data validation
+   - Simple transformations
+   - Quick API integrations
+
+2. **Long-running Tasks**: Use asynchronous mode with webhooks
+   - Complex data processing
+   - Multi-step workflows
+   - Resource-intensive operations
+
+3. **Integration Workflows**: Build automated pipelines
+   - Connect with n8n or make.com
+   - Chain multiple services
+   - Process results automatically
+
+4. **Real-time Monitoring**: Track progress with webhooks
+   - Monitor job execution
+   - Get plugin-level updates
+   - Handle errors immediately
+
+## Event System
+
+The service provides real-time updates through four event types:
+
+- `started`: Job execution has begun
+- `progress`: Plugin execution updates
+- `completed`: Job finished successfully
+- `failed`: Job encountered an error
+
+Configure which events to receive:
+
+```json
+{
+  "webhook": {
+    "url": "https://your-server.com/webhook",
+    "on": ["started", "completed", "failed"]
+  }
+}
+```
 
 ## Contributing
 

--- a/docs/playground/api/README.md
+++ b/docs/playground/api/README.md
@@ -1,0 +1,131 @@
+# Playground API Reference
+
+The Playground service exposes a RESTful API for managing execution jobs and plugins.
+
+## Endpoints
+
+### Create Job
+
+```http
+POST /playground/jobs
+```
+
+Create a new playground job with specified configuration.
+
+#### Request Body
+
+```typescript
+{
+  input: any;              // Input data for the job
+  timeout?: number;        // Optional timeout in milliseconds
+  retries?: number;        // Optional number of retries (default: 3)
+  plugins?: string[];      // Optional list of specific plugins to run
+  debug?: boolean;         // Optional debug mode flag
+}
+```
+
+#### Response
+
+```typescript
+{
+  id: string;             // Unique job ID
+  config: {...};          // Job configuration
+  progress: {
+    status: string;       // Job status
+    startTime: string;    // Start timestamp
+    completedPlugins: string[];  // Completed plugin names
+  };
+  // Additional job metadata
+}
+```
+
+### Start Job
+
+```http
+POST /playground/jobs/:id/start
+```
+
+Start executing a previously created job.
+
+#### Response
+
+```typescript
+{
+  id: string;             // Job ID
+  config: {...};          // Job configuration
+  progress: {...};        // Current progress
+  result?: {             // Optional result object
+    metrics: any[];      // Plugin metrics
+    summary?: any;       // Optional summary
+  };
+}
+```
+
+### Get Job Status
+
+```http
+GET /playground/jobs/:id
+```
+
+Retrieve the current status and results of a job.
+
+#### Response
+
+```typescript
+{
+  id: string;             // Job ID
+  config: {...};          // Job configuration
+  progress: {...};        // Current progress
+  result?: {...};         // Optional result object
+}
+```
+
+### Get Job Progress
+
+```http
+GET /playground/jobs/:id/progress
+```
+
+Get detailed progress information for a job.
+
+#### Response
+
+```typescript
+{
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  startTime: string;      // Start timestamp
+  endTime?: string;       // Optional completion timestamp
+  error?: string;         // Optional error message
+  currentPlugin?: string; // Currently running plugin
+  completedPlugins: string[];  // List of completed plugins
+}
+```
+
+## Error Handling
+
+The API uses standard HTTP status codes:
+
+- `200`: Success
+- `404`: Job not found
+- `500`: Server error
+
+Error responses include a message:
+
+```typescript
+{
+  error: string;  // Error description
+}
+```
+
+## Event System
+
+The Playground service emits events during job execution that can be consumed by external systems. These events include:
+
+- `jobStart`: Job execution started
+- `jobComplete`: Job execution completed
+- `jobError`: Job execution failed
+- `pluginStart`: Plugin execution started
+- `pluginComplete`: Plugin execution completed
+- `pluginError`: Plugin execution failed
+
+Each event includes relevant data about the job and its current state. For detailed information about consuming these events and integrating with external systems, see the [Webhook Events Guide](../guides/webhooks.md).

--- a/docs/playground/examples/README.md
+++ b/docs/playground/examples/README.md
@@ -1,0 +1,266 @@
+# Playground Examples
+
+This guide provides practical examples of using the Playground service for various use cases. Each example includes complete code and explanations.
+
+## Table of Contents
+
+1. [Data Processing Pipeline](#data-processing-pipeline)
+2. [API Integration Chain](#api-integration-chain)
+3. [Data Validation System](#data-validation-system)
+4. [Machine Learning Pipeline](#machine-learning-pipeline)
+5. [Document Processing](#document-processing)
+
+## Data Processing Pipeline
+
+Create a pipeline that processes data through multiple stages.
+
+### Plugin Implementation
+
+```typescript
+interface ProcessingMetric {
+  stage: string;
+  processedCount: number;
+  timestamp: Date;
+}
+
+class DataProcessingPlugin implements PlaygroundPlugin<ProcessingMetric> {
+  name = 'data-processor';
+  enabled = true;
+
+  async execute(context: PlaygroundContext): Promise<ProcessingMetric> {
+    const { data } = context.input;
+    
+    // Process data
+    const processed = data.map(item => ({
+      ...item,
+      processed: true,
+      timestamp: new Date()
+    }));
+
+    // Store results
+    await context.storage.set('processed_data', processed);
+
+    return {
+      stage: 'processing',
+      processedCount: processed.length,
+      timestamp: new Date()
+    };
+  }
+}
+```
+
+### Usage Example
+
+```bash
+curl -X POST http://localhost:3000/playground/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "data": [
+        {"id": 1, "value": "test1"},
+        {"id": 2, "value": "test2"}
+      ]
+    },
+    "plugins": ["data-processor"]
+  }'
+```
+
+## API Integration Chain
+
+Chain multiple API calls with data transformation between them.
+
+### Plugin Implementation
+
+```typescript
+interface ApiChainMetric {
+  source: string;
+  responseStatus: number;
+  transformedData: any;
+}
+
+class ApiChainPlugin implements PlaygroundPlugin<ApiChainMetric> {
+  name = 'api-chain';
+  enabled = true;
+
+  async execute(context: PlaygroundContext): Promise<ApiChainMetric> {
+    const { endpoint, transformFn } = context.input;
+
+    // Make API call
+    const response = await fetch(endpoint);
+    const data = await response.json();
+
+    // Transform data
+    const transformed = eval(transformFn)(data);
+
+    return {
+      source: endpoint,
+      responseStatus: response.status,
+      transformedData: transformed
+    };
+  }
+}
+```
+
+### Usage with n8n
+
+```typescript
+// n8n Workflow
+{
+  "nodes": [
+    {
+      "name": "Event Listener",
+      "type": "n8n-nodes-base.webhook",
+      "parameters": {
+        "path": "api-chain-events",
+        "options": {}
+      }
+    },
+    {
+      "name": "HTTP Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "url": "http://localhost:3000/playground/jobs",
+        "method": "POST",
+        "body": {
+          "input": {
+            "endpoint": "https://api.example.com/data",
+            "transformFn": "data => data.map(x => x.value.toUpperCase())"
+          },
+          "plugins": ["api-chain"]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Data Validation System
+
+Implement a validation system with custom rules and reporting.
+
+### Plugin Implementation
+
+```typescript
+interface ValidationMetric {
+  valid: boolean;
+  errors: string[];
+  timestamp: Date;
+}
+
+class ValidationPlugin implements PlaygroundPlugin<ValidationMetric> {
+  name = 'validator';
+  enabled = true;
+
+  async execute(context: PlaygroundContext): Promise<ValidationMetric> {
+    const { schema, data } = context.input;
+    const errors: string[] = [];
+
+    // Validate against schema
+    Object.entries(schema).forEach(([field, rules]) => {
+      if (!this.validateField(data[field], rules)) {
+        errors.push(`Invalid ${field}`);
+      }
+    });
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      timestamp: new Date()
+    };
+  }
+
+  private validateField(value: any, rules: any): boolean {
+    // Implementation of validation rules
+    return true; // Simplified for example
+  }
+}
+```
+
+### Usage with Make.com
+
+```typescript
+// Make.com Scenario
+{
+  "trigger": {
+    "type": "event",
+    "path": "validation-events"
+  },
+  "actions": [
+    {
+      "type": "http",
+      "url": "http://localhost:3000/playground/jobs",
+      "method": "POST",
+      "body": {
+        "input": {
+          "schema": {
+            "email": { "type": "email", "required": true },
+            "age": { "type": "number", "min": 18 }
+          },
+          "data": {
+            "email": "test@example.com",
+            "age": 25
+          }
+        },
+        "plugins": ["validator"]
+      }
+    }
+  ]
+}
+```
+
+## Integration Patterns
+
+### 1. Event-Driven Processing
+
+Chain operations based on events:
+
+```typescript
+// Event listener triggers new job based on completion
+Event → Process Results → Start New Job → Process Final Results
+```
+
+### 2. Conditional Processing
+
+Use events to make decisions:
+
+```typescript
+// n8n decision workflow
+Event Listener → Switch Node (based on result) →
+  → Success: Process data
+  → Error: Notify team
+```
+
+### 3. Parallel Processing
+
+Run multiple jobs and aggregate results:
+
+```typescript
+// Make.com parallel scenario
+Trigger → Split → 
+  → Job 1
+  → Job 2
+  → Job 3
+→ Aggregate Results
+```
+
+## Best Practices
+
+1. **Error Handling**
+   - Implement proper try/catch blocks
+   - Handle events properly
+   - Log errors comprehensively
+
+2. **Performance**
+   - Process data in chunks
+   - Implement proper timeouts
+   - Use caching when appropriate
+
+3. **Monitoring**
+   - Track job progress
+   - Monitor resource usage
+   - Set up alerts for failures
+
+4. **Security**
+   - Validate input data
+   - Implement proper authentication
+   - Sanitize outputs

--- a/docs/playground/guides/getting-started.md
+++ b/docs/playground/guides/getting-started.md
@@ -1,0 +1,222 @@
+# Getting Started with Playground
+
+This guide will help you quickly get started with the Playground service, a flexible execution environment for running custom code through plugins.
+
+## Overview
+
+The Playground service allows you to:
+
+- Execute custom code through plugins
+- Process data with configurable pipelines
+- Track execution progress and results
+- Chain multiple processing steps
+- Integrate with external systems through events
+
+## Quick Start
+
+### 1. Create a Job
+
+First, create a job with your input data:
+
+```bash
+curl -X POST http://localhost:3000/playground/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "data": "your input data"
+    },
+    "plugins": ["example-plugin"]
+  }'
+```
+
+Response:
+
+```json
+{
+  "id": "job-123",
+  "config": {
+    "input": {
+      "data": "your input data"
+    },
+    "plugins": ["example-plugin"]
+  },
+  "progress": {
+    "status": "queued",
+    "startTime": "2025-01-03T19:54:17.000Z",
+    "completedPlugins": []
+  }
+}
+```
+
+### 2. Start the Job
+
+Use the job ID to start execution:
+
+```bash
+curl -X POST http://localhost:3000/playground/jobs/job-123/start
+```
+
+### 3. Check Progress
+
+Monitor the job's progress:
+
+```bash
+curl http://localhost:3000/playground/jobs/job-123/progress
+```
+
+## Basic Configuration
+
+### Job Configuration Options
+
+```typescript
+{
+  // Required
+  input: any;              // Input data for processing
+
+  // Optional
+  timeout?: number;        // Processing timeout (ms)
+  retries?: number;        // Number of retry attempts
+  plugins?: string[];      // Specific plugins to run
+  debug?: boolean;         // Enable debug mode
+}
+```
+
+## Using Built-in Plugins
+
+The service comes with some built-in plugins. Here's how to use them:
+
+### Example Plugin
+
+```bash
+curl -X POST http://localhost:3000/playground/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "data": "test data"
+    },
+    "plugins": ["example-plugin"]
+  }'
+```
+
+## Monitoring Jobs
+
+### Get Job Details
+
+```bash
+curl http://localhost:3000/playground/jobs/job-123
+```
+
+Response includes:
+
+- Current status
+- Progress information
+- Plugin results
+- Error details (if any)
+
+### Track Progress
+
+```bash
+curl http://localhost:3000/playground/jobs/job-123/progress
+```
+
+Response shows:
+
+- Current status
+- Completed plugins
+- Running plugin
+- Error information
+
+## Error Handling
+
+The service provides detailed error information:
+
+```json
+{
+  "error": {
+    "message": "Error description",
+    "plugin": "plugin-name",
+    "timestamp": "2025-01-03T19:54:17.000Z"
+  }
+}
+```
+
+## Next Steps
+
+1. [Create Custom Plugins](../plugins/README.md)
+   - Learn how to create plugins
+   - Understand plugin lifecycle
+   - Implement custom logic
+
+2. [Event System](./webhooks.md)
+   - Understand available events
+   - Integrate with external systems
+   - Handle event data
+
+3. [Explore Examples](../examples/README.md)
+   - View implementation examples
+   - Learn integration patterns
+   - Understand best practices
+
+## Common Use Cases
+
+1. **Data Processing**
+   - Transform data formats
+   - Validate input data
+   - Generate reports
+
+2. **API Integration**
+   - Chain API calls
+   - Transform responses
+   - Handle errors
+
+3. **Automation**
+   - Schedule jobs
+   - Process queues
+   - Monitor results
+
+## Tips and Best Practices
+
+1. **Job Management**
+   - Use meaningful input data
+   - Set appropriate timeouts
+   - Configure retry attempts
+
+2. **Event Handling**
+   - Listen for relevant events
+   - Process events asynchronously
+   - Handle event failures
+
+3. **Error Handling**
+   - Check job status regularly
+   - Monitor event emissions
+   - Log error details
+
+4. **Performance**
+   - Process data in chunks
+   - Use appropriate plugins
+   - Monitor resource usage
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Job Not Starting**
+   - Check job ID
+   - Verify input format
+   - Check plugin availability
+
+2. **Event Issues**
+   - Verify event listener setup
+   - Check event data format
+   - Review error messages
+
+3. **Plugin Errors**
+   - Check plugin configuration
+   - Verify input data
+   - Review error messages
+
+### Getting Help
+
+- Check the [API Reference](../api/README.md)
+- Review [Example Code](../examples/README.md)
+- Examine error messages and logs

--- a/docs/playground/guides/webhooks.md
+++ b/docs/playground/guides/webhooks.md
@@ -1,112 +1,140 @@
-# Event System Guide
+# Webhook Integration Guide
 
-The Playground service provides a comprehensive event system that allows external systems to monitor and react to job and plugin execution events. This guide explains how to integrate with these events using automation platforms like n8n and Make.com.
+The Playground service provides a comprehensive webhook system for real-time notifications about job and plugin execution events. This guide explains how to configure webhooks and integrate them with automation platforms like n8n and Make.com.
 
-## Available Events
+## Webhook Configuration
 
-The service emits the following events:
-
-### Job Events
-
-1. **jobStart**
+When creating a job, you can specify webhook settings:
 
 ```typescript
 {
-  "event": "jobStart",
-  "data": {
-    "jobId": "job-123",
-    "job": {
-      "id": "job-123",
-      "config": {...},
-      "progress": {...}
-    }
-  },
-  "timestamp": "2025-01-03T19:54:37.000Z"
+  "webhook": {
+    "url": "https://your-webhook-endpoint.com/hook",
+    "headers": {
+      "Authorization": "Bearer your-token",
+      "Custom-Header": "custom-value"
+    },
+    "on": ["completed", "failed"],  // Optional: specific events to receive
+    "retries": 3  // Optional: retry count
+  }
 }
 ```
 
-2. **jobComplete**
+## Event Types
+
+The service supports four distinct event types:
+
+1. **started**
+   - Emitted when job execution begins
+   - Includes job configuration and input data
+
+2. **progress**
+   - Emitted after each plugin completes
+   - Includes plugin metrics and current progress
+
+3. **completed**
+   - Emitted when job successfully finishes
+   - Includes complete results and execution summary
+
+4. **failed**
+   - Emitted when job encounters an error
+   - Includes error details and final progress state
+
+## Event Filtering
+
+Use the `on` property to specify which events you want to receive:
 
 ```typescript
 {
-  "event": "jobComplete",
-  "data": {
-    "jobId": "job-123",
-    "job": {
-      "id": "job-123",
-      "config": {...},
-      "progress": {...},
-      "result": {
-        "metrics": [...],
-        "summary": {...}
+  "webhook": {
+    "url": "https://your-endpoint.com/hook",
+    "on": ["started", "completed"]  // Only receive these events
+  }
+}
+```
+
+If `on` is not specified, you'll receive all event types.
+
+## Event Payloads
+
+### Started Event
+
+```json
+{
+  "status": "started",
+  "jobId": "job-123",
+  "timestamp": "2025-01-03T19:06:00.000Z",
+  "config": {
+    "input": {
+      "data": "your input"
+    },
+    "plugins": ["example-plugin"]
+  }
+}
+```
+
+### Progress Event
+
+```json
+{
+  "status": "progress",
+  "jobId": "job-123",
+  "timestamp": "2025-01-03T19:06:00.000Z",
+  "pluginName": "example-plugin",
+  "metrics": {
+    "processedItems": 10,
+    "duration": 1500
+  },
+  "progress": {
+    "status": "running",
+    "completedPlugins": ["example-plugin"],
+    "currentPlugin": "next-plugin"
+  }
+}
+```
+
+### Completed Event
+
+```json
+{
+  "status": "completed",
+  "jobId": "job-123",
+  "timestamp": "2025-01-03T19:06:00.000Z",
+  "result": {
+    "metrics": [
+      {
+        "plugin-name": {
+          "processedItems": 10,
+          "duration": 1500
+        }
       }
+    ],
+    "summary": {
+      "totalProcessed": 10,
+      "averageTime": 1500
     }
   },
-  "timestamp": "2025-01-03T19:54:37.000Z"
+  "summary": {
+    "duration": 3000,
+    "completedPlugins": ["example-plugin", "next-plugin"]
+  }
 }
 ```
 
-3. **jobError**
+### Failed Event
 
-```typescript
+```json
 {
-  "event": "jobError",
-  "data": {
-    "jobId": "job-123",
-    "error": {
-      "message": "Error description"
-    },
-    "job": {...}
-  },
-  "timestamp": "2025-01-03T19:54:37.000Z"
-}
-```
-
-### Plugin Events
-
-1. **pluginStart**
-
-```typescript
-{
-  "event": "pluginStart",
-  "data": {
-    "jobId": "job-123",
-    "pluginName": "example-plugin",
-    "job": {...}
-  },
-  "timestamp": "2025-01-03T19:54:37.000Z"
-}
-```
-
-2. **pluginComplete**
-
-```typescript
-{
-  "event": "pluginComplete",
-  "data": {
-    "jobId": "job-123",
-    "pluginName": "example-plugin",
-    "metrics": {...},
-    "job": {...}
-  },
-  "timestamp": "2025-01-03T19:54:37.000Z"
-}
-```
-
-3. **pluginError**
-
-```typescript
-{
-  "event": "pluginError",
-  "data": {
-    "jobId": "job-123",
-    "pluginName": "example-plugin",
-    "error": {
-      "message": "Plugin error description"
-    },
-    "job": {...}
-  },
-  "timestamp": "2025-01-03T19:54:37.000Z"
+  "status": "failed",
+  "jobId": "job-123",
+  "timestamp": "2025-01-03T19:06:00.000Z",
+  "error": "Plugin execution failed",
+  "progress": {
+    "status": "failed",
+    "error": "Plugin execution failed",
+    "completedPlugins": ["example-plugin"],
+    "currentPlugin": "failed-plugin"
+  }
 }
 ```
 
@@ -114,9 +142,9 @@ The service emits the following events:
 
 ### n8n Integration
 
-n8n is a powerful workflow automation platform that can listen for events and trigger automated workflows.
+n8n is a powerful workflow automation platform that can receive webhook events and trigger automated workflows.
 
-1. **Event Listener Workflow**
+1. **Event Listener Setup**
 
 ```typescript
 // n8n Webhook Node Configuration
@@ -130,30 +158,27 @@ n8n is a powerful workflow automation platform that can listen for events and tr
 }
 
 // Example workflow:
-// 1. Event Listener
-// 2. Switch Node (based on event type)
-// 3. Actions based on event:
-//    - Store results in database
-//    - Send notifications
-//    - Trigger other processes
+// 1. Webhook Node: Listen for events
+// 2. Switch Node: Route based on event.status
+// 3. Action Nodes: Process each event type
 ```
 
 2. **Error Handling Workflow**
 
 ```typescript
-// Listen for pluginError or jobError events
-// Send notifications via email/Slack
+// Listen for 'failed' events
+// Send alerts via email/Slack
 // Log errors to monitoring system
 ```
 
-### Make.com (Formerly Integromat) Integration
+### Make.com Integration
 
-Make.com provides visual workflow automation with excellent event handling capabilities.
+Make.com provides visual workflow automation with excellent webhook support.
 
-1. **Real-time Processing Workflow**
+1. **Real-time Processing**
 
 ```typescript
-// Make.com Event Listener Configuration
+// Make.com Webhook Configuration
 {
   "type": "instant",
   "headers": {
@@ -162,112 +187,75 @@ Make.com provides visual workflow automation with excellent event handling capab
 }
 
 // Example scenario:
-// 1. Event Listener → receive event
-// 2. Router → based on event type
-// 3. Actions:
-//    - Update CRM
-//    - Send notifications
-//    - Process results
+// 1. Webhook → receive event
+// 2. Router → based on event.status
+// 3. Actions based on event type
 ```
 
 ## Use Cases
 
-### 1. Data Pipeline Automation
+### 1. Progress Monitoring
 
-Create automated data processing pipelines:
-
-- Listen for job completion events
-- Process results automatically
-- Load processed data into target systems
+Create real-time progress dashboards:
 
 ```typescript
-// Example Make.com scenario
-Event Listener → Filter → Transform → Database
+// Listen for 'progress' events
+Webhook → Update Dashboard → Store Metrics
 ```
 
-### 2. Error Monitoring
+### 2. Error Alerting
 
 Set up comprehensive error monitoring:
 
-- Capture all error events
-- Send alerts to appropriate channels
-- Log errors for analysis
-
 ```typescript
-// Example n8n workflow
-Event Listener → Switch → 
-  → Slack (urgent alerts)
-  → Email (daily summaries)
-  → Log Database
+// Listen for 'failed' events
+Webhook → Alert System → Error Database
 ```
 
-### 3. Progress Tracking
+### 3. Result Processing
 
-Monitor job progress in real-time:
-
-- Track plugin execution events
-- Update progress dashboards
-- Generate timing metrics
+Automate result handling:
 
 ```typescript
-// Example integration
-Event Listener → Process Events → 
-  → Update Dashboard
-  → Store Metrics
-  → Generate Reports
-```
-
-### 4. Multi-system Integration
-
-Coordinate multiple systems:
-
-- React to job events
-- Synchronize data across platforms
-- Maintain audit trails
-
-```typescript
-// Example workflow
-Event Listener → Router →
-  → CRM Update
-  → Analytics Platform
-  → Audit Log
+// Listen for 'completed' events
+Webhook → Process Results → Update Systems
 ```
 
 ## Best Practices
 
-1. **Reliability**
-   - Implement proper error handling
-   - Use event queues
-   - Store failed event processing attempts
+1. **Event Filtering**
+   - Only subscribe to needed events
+   - Process events asynchronously
+   - Handle each event type appropriately
 
-2. **Security**
-   - Use secure connections
+2. **Reliability**
+   - Implement proper error handling
+   - Use webhook retries
+   - Log delivery attempts
+
+3. **Security**
+   - Use HTTPS endpoints
    - Implement authentication
    - Validate event data
 
-3. **Performance**
-   - Process events asynchronously
+4. **Performance**
+   - Process events efficiently
    - Implement proper timeouts
-   - Monitor processing times
-
-4. **Monitoring**
-   - Log event processing attempts
-   - Track success/failure rates
    - Monitor processing times
 
 ## Troubleshooting
 
-1. **Event Not Received**
-   - Check event listener configuration
-   - Verify network/firewall settings
-   - Check authentication settings
+1. **Missing Events**
+   - Check event filtering configuration
+   - Verify webhook URL accessibility
+   - Review server logs
 
-2. **Processing Issues**
-   - Verify event data format
-   - Check handler logic
-   - Review error logs
+2. **Failed Deliveries**
+   - Check retry configuration
+   - Verify endpoint availability
+   - Monitor error logs
 
-3. **Integration Problems**
-   - Verify system connectivity
-   - Check data mapping
+3. **Processing Issues**
+   - Validate event payload handling
+   - Check business logic
    - Review system logs

--- a/docs/playground/guides/webhooks.md
+++ b/docs/playground/guides/webhooks.md
@@ -1,0 +1,273 @@
+# Event System Guide
+
+The Playground service provides a comprehensive event system that allows external systems to monitor and react to job and plugin execution events. This guide explains how to integrate with these events using automation platforms like n8n and Make.com.
+
+## Available Events
+
+The service emits the following events:
+
+### Job Events
+
+1. **jobStart**
+
+```typescript
+{
+  "event": "jobStart",
+  "data": {
+    "jobId": "job-123",
+    "job": {
+      "id": "job-123",
+      "config": {...},
+      "progress": {...}
+    }
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+2. **jobComplete**
+
+```typescript
+{
+  "event": "jobComplete",
+  "data": {
+    "jobId": "job-123",
+    "job": {
+      "id": "job-123",
+      "config": {...},
+      "progress": {...},
+      "result": {
+        "metrics": [...],
+        "summary": {...}
+      }
+    }
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+3. **jobError**
+
+```typescript
+{
+  "event": "jobError",
+  "data": {
+    "jobId": "job-123",
+    "error": {
+      "message": "Error description"
+    },
+    "job": {...}
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+### Plugin Events
+
+1. **pluginStart**
+
+```typescript
+{
+  "event": "pluginStart",
+  "data": {
+    "jobId": "job-123",
+    "pluginName": "example-plugin",
+    "job": {...}
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+2. **pluginComplete**
+
+```typescript
+{
+  "event": "pluginComplete",
+  "data": {
+    "jobId": "job-123",
+    "pluginName": "example-plugin",
+    "metrics": {...},
+    "job": {...}
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+3. **pluginError**
+
+```typescript
+{
+  "event": "pluginError",
+  "data": {
+    "jobId": "job-123",
+    "pluginName": "example-plugin",
+    "error": {
+      "message": "Plugin error description"
+    },
+    "job": {...}
+  },
+  "timestamp": "2025-01-03T19:54:37.000Z"
+}
+```
+
+## Integration Examples
+
+### n8n Integration
+
+n8n is a powerful workflow automation platform that can listen for events and trigger automated workflows.
+
+1. **Event Listener Workflow**
+
+```typescript
+// n8n Webhook Node Configuration
+{
+  "authentication": "headerAuth",
+  "headerName": "Authorization",
+  "headerValue": "Bearer your-token",
+  "path": "playground-events",
+  "responseMode": "lastNode",
+  "responseData": "allEntries"
+}
+
+// Example workflow:
+// 1. Event Listener
+// 2. Switch Node (based on event type)
+// 3. Actions based on event:
+//    - Store results in database
+//    - Send notifications
+//    - Trigger other processes
+```
+
+2. **Error Handling Workflow**
+
+```typescript
+// Listen for pluginError or jobError events
+// Send notifications via email/Slack
+// Log errors to monitoring system
+```
+
+### Make.com (Formerly Integromat) Integration
+
+Make.com provides visual workflow automation with excellent event handling capabilities.
+
+1. **Real-time Processing Workflow**
+
+```typescript
+// Make.com Event Listener Configuration
+{
+  "type": "instant",
+  "headers": {
+    "Authorization": "Bearer your-token"
+  }
+}
+
+// Example scenario:
+// 1. Event Listener → receive event
+// 2. Router → based on event type
+// 3. Actions:
+//    - Update CRM
+//    - Send notifications
+//    - Process results
+```
+
+## Use Cases
+
+### 1. Data Pipeline Automation
+
+Create automated data processing pipelines:
+
+- Listen for job completion events
+- Process results automatically
+- Load processed data into target systems
+
+```typescript
+// Example Make.com scenario
+Event Listener → Filter → Transform → Database
+```
+
+### 2. Error Monitoring
+
+Set up comprehensive error monitoring:
+
+- Capture all error events
+- Send alerts to appropriate channels
+- Log errors for analysis
+
+```typescript
+// Example n8n workflow
+Event Listener → Switch → 
+  → Slack (urgent alerts)
+  → Email (daily summaries)
+  → Log Database
+```
+
+### 3. Progress Tracking
+
+Monitor job progress in real-time:
+
+- Track plugin execution events
+- Update progress dashboards
+- Generate timing metrics
+
+```typescript
+// Example integration
+Event Listener → Process Events → 
+  → Update Dashboard
+  → Store Metrics
+  → Generate Reports
+```
+
+### 4. Multi-system Integration
+
+Coordinate multiple systems:
+
+- React to job events
+- Synchronize data across platforms
+- Maintain audit trails
+
+```typescript
+// Example workflow
+Event Listener → Router →
+  → CRM Update
+  → Analytics Platform
+  → Audit Log
+```
+
+## Best Practices
+
+1. **Reliability**
+   - Implement proper error handling
+   - Use event queues
+   - Store failed event processing attempts
+
+2. **Security**
+   - Use secure connections
+   - Implement authentication
+   - Validate event data
+
+3. **Performance**
+   - Process events asynchronously
+   - Implement proper timeouts
+   - Monitor processing times
+
+4. **Monitoring**
+   - Log event processing attempts
+   - Track success/failure rates
+   - Monitor processing times
+
+## Troubleshooting
+
+1. **Event Not Received**
+   - Check event listener configuration
+   - Verify network/firewall settings
+   - Check authentication settings
+
+2. **Processing Issues**
+   - Verify event data format
+   - Check handler logic
+   - Review error logs
+
+3. **Integration Problems**
+   - Verify system connectivity
+   - Check data mapping
+   - Review system logs

--- a/docs/playground/plugins/README.md
+++ b/docs/playground/plugins/README.md
@@ -1,0 +1,213 @@
+# Creating Playground Plugins
+
+The Playground service uses a flexible plugin system that allows you to create custom code execution and analysis modules. This guide explains how to create and implement your own plugins.
+
+## Plugin Interface
+
+Every plugin must implement the `PlaygroundPlugin` interface:
+
+```typescript
+interface PlaygroundPlugin<TMetric = any, TSummary = any> {
+  name: string;                   // Unique plugin name
+  enabled: boolean;               // Plugin enabled state
+  storage?: PlaygroundStorage;    // Optional plugin storage
+  initialize?(): Promise<void>;   // Optional initialization
+  before?(context: PlaygroundContext): Promise<void>;    // Pre-execution hook
+  execute(context: PlaygroundContext): Promise<TMetric>; // Main execution
+  after?(context: PlaygroundContext): Promise<void>;     // Post-execution hook
+  summarize?(metrics: TMetric[]): Promise<TSummary>;     // Optional results summary
+}
+```
+
+## Creating a Plugin
+
+Here's an example of a basic plugin:
+
+```typescript
+import { PlaygroundPlugin, PlaygroundContext } from '../types';
+
+interface ExampleMetric {
+  processedAt: Date;
+  result: string;
+}
+
+interface ExampleSummary {
+  totalProcessed: number;
+  averageProcessingTime: number;
+}
+
+export class ExamplePlugin implements PlaygroundPlugin<ExampleMetric, ExampleSummary> {
+  name = 'example-plugin';
+  enabled = true;
+
+  async initialize(): Promise<void> {
+    // Optional: Set up plugin resources
+    console.log('Initializing example plugin');
+  }
+
+  async before(context: PlaygroundContext): Promise<void> {
+    // Optional: Pre-execution setup
+    await context.storage.set('startTime', new Date());
+  }
+
+  async execute(context: PlaygroundContext): Promise<ExampleMetric> {
+    // Main plugin logic
+    const processedAt = new Date();
+    const result = `Processed input: ${JSON.stringify(context.input)}`;
+
+    return {
+      processedAt,
+      result
+    };
+  }
+
+  async after(context: PlaygroundContext): Promise<void> {
+    // Optional: Clean up or post-processing
+    const startTime = await context.storage.get<Date>('startTime');
+    console.log(`Processing took: ${new Date().getTime() - startTime!.getTime()}ms`);
+  }
+
+  async summarize(metrics: ExampleMetric[]): Promise<ExampleSummary> {
+    // Optional: Summarize multiple execution results
+    const totalProcessed = metrics.length;
+    const totalTime = metrics.reduce((sum, m) => 
+      sum + m.processedAt.getTime(), 0);
+
+    return {
+      totalProcessed,
+      averageProcessingTime: totalTime / totalProcessed
+    };
+  }
+}
+```
+
+## Plugin Context
+
+Plugins receive a `PlaygroundContext` object that provides:
+
+```typescript
+interface PlaygroundContext {
+  jobId: string;          // Current job ID
+  input: any;             // Job input data
+  output?: any;           // Optional output data
+  startTime: Date;        // Execution start time
+  storage: PlaygroundStorage;  // Plugin storage
+  [key: string]: any;     // Additional context data
+}
+```
+
+## Plugin Storage
+
+Each plugin has access to a storage system for maintaining state:
+
+```typescript
+interface PlaygroundStorage {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+```
+
+## Plugin Lifecycle
+
+1. **Initialization**: When the service starts, each plugin's `initialize()` method is called
+2. **Pre-execution**: Before execution, `before()` is called with the job context
+3. **Execution**: The `execute()` method runs the main plugin logic
+4. **Post-execution**: After execution, `after()` is called for cleanup
+5. **Summary**: If multiple metrics are collected, `summarize()` can process them
+
+## Best Practices
+
+1. **Type Safety**
+   - Use TypeScript generics for metric and summary types
+   - Define clear interfaces for your data structures
+   - Avoid using `any` where possible
+
+2. **Error Handling**
+   - Implement proper try/catch blocks
+   - Return meaningful error messages
+   - Clean up resources in case of errors
+
+3. **Storage Usage**
+   - Use storage for temporary data only
+   - Clean up after plugin execution
+   - Handle storage errors gracefully
+
+4. **Performance**
+   - Keep plugins focused and lightweight
+   - Implement proper cleanup in `after()`
+   - Use async/await for asynchronous operations
+
+## Example Use Cases
+
+1. **Data Transformation**
+
+```typescript
+async execute(context: PlaygroundContext): Promise<TransformMetric> {
+  const { input } = context;
+  const transformed = someTransformation(input);
+  return { transformed, timestamp: new Date() };
+}
+```
+
+2. **API Integration**
+
+```typescript
+async execute(context: PlaygroundContext): Promise<ApiMetric> {
+  const { apiKey, endpoint } = context.input;
+  const response = await fetch(endpoint, {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  });
+  return { data: await response.json(), timestamp: new Date() };
+}
+```
+
+3. **Data Validation**
+
+```typescript
+async execute(context: PlaygroundContext): Promise<ValidationMetric> {
+  const { schema, data } = context.input;
+  const validationResult = validateAgainstSchema(schema, data);
+  return { valid: validationResult.valid, errors: validationResult.errors };
+}
+```
+
+## Testing Plugins
+
+Create comprehensive tests for your plugins:
+
+```typescript
+describe('ExamplePlugin', () => {
+  let plugin: ExamplePlugin;
+  let context: PlaygroundContext;
+
+  beforeEach(() => {
+    plugin = new ExamplePlugin();
+    context = {
+      jobId: 'test-job',
+      input: { test: 'data' },
+      startTime: new Date(),
+      storage: new MemoryStorage()
+    };
+  });
+
+  it('should process input correctly', async () => {
+    const result = await plugin.execute(context);
+    expect(result.result).toContain('test: data');
+  });
+});
+```
+
+## Registering Plugins
+
+Register your plugins when creating the PlaygroundService:
+
+```typescript
+const playgroundService = new PlaygroundService({
+  plugins: [
+    new ExamplePlugin(),
+    new YourCustomPlugin()
+  ],
+  config: { debug: true }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       add:
         specifier: ^2.0.6
         version: 2.0.6
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       bull:
         specifier: ^4.16.3
         version: 4.16.5
@@ -989,6 +992,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
@@ -1637,6 +1643,15 @@ packages:
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-in@0.1.8:
     resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
@@ -4106,6 +4121,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   b4a@1.6.7: {}
 
   balanced-match@1.0.2: {}
@@ -4873,6 +4896,8 @@ snapshots:
   flatted@3.3.2: {}
 
   fn.name@1.1.0: {}
+
+  follow-redirects@1.15.9: {}
 
   for-in@0.1.8: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import healthRoutes from './routes/health';
 import linkedinRoutes from './routes/linkedin';
 import testRoutes from './routes/test';
 import { TunnelService } from './services/tunnel-service';
+import playgroundRouter from './routes/playground';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -30,6 +31,7 @@ app.use('/api', apiRoutes);
 app.use('/crawl', crawlRoutes);
 app.use('/linkedin', linkedinRoutes);
 app.use('/test', testRoutes);
+app.use('/playground', playgroundRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/routes/playground.ts
+++ b/src/routes/playground.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import { PlaygroundService } from '../services/playground/playground';
+import { ExamplePlugin } from '../services/playground/plugins/example-plugin';
+
+const router = Router();
+const playgroundService = new PlaygroundService({
+  plugins: [new ExamplePlugin()],
+  config: { debug: process.env.NODE_ENV === 'development' },
+});
+
+// Create a new playground job
+router.post('/jobs', async (req, res) => {
+  try {
+    const job = await playgroundService.createJob({
+      input: req.body.input,
+      retries: req.body.retries ?? 3,
+      plugins: req.body.plugins,
+    });
+
+    res.json(job);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+// Start a job
+router.post('/jobs/:id/start', async (req, res) => {
+  try {
+    const job = await playgroundService.startJob(req.params.id);
+    res.json(job);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+// Get job status
+router.get('/jobs/:id', async (req, res) => {
+  try {
+    const job = await playgroundService.getJob(req.params.id);
+    res.json(job);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not found')) {
+      res.status(404).json({ error: error.message });
+    } else {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+});
+
+// Get job progress
+router.get('/jobs/:id/progress', async (req, res) => {
+  try {
+    const progress = await playgroundService.getProgress(req.params.id);
+    res.json(progress);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not found')) {
+      res.status(404).json({ error: error.message });
+    } else {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+});
+
+export default router;

--- a/src/services/playground/__tests__/example-plugin.test.ts
+++ b/src/services/playground/__tests__/example-plugin.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ExamplePlugin } from '../plugins/example-plugin';
+import type { PlaygroundContext } from '../types';
+
+describe('ExamplePlugin', () => {
+  let plugin: ExamplePlugin;
+  let context: PlaygroundContext;
+
+  beforeEach(() => {
+    plugin = new ExamplePlugin();
+    context = {
+      jobId: 'test-job',
+      input: '',
+      startTime: new Date(),
+      storage: {
+        get: async () => null,
+        set: async () => {},
+        delete: async () => {},
+        clear: async () => {},
+      },
+    };
+  });
+
+  describe('initialize', () => {
+    it('should initialize without error', async () => {
+      await expect(plugin.initialize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('before', () => {
+    it('should set startTime in storage', async () => {
+      const setMock = vi.fn();
+      context.storage.set = setMock;
+
+      await plugin.before(context);
+
+      expect(setMock).toHaveBeenCalledWith('startTime', expect.any(Number));
+    });
+  });
+
+  describe('execute', () => {
+    it('should reverse string input', async () => {
+      context.input = 'hello';
+      const result = await plugin.execute(context);
+
+      expect(context.output).toBe('olleh');
+      expect(result).toEqual({
+        processedAt: expect.any(Date),
+        inputLength: 5,
+        outputLength: 5,
+        processingTimeMs: expect.any(Number),
+      });
+    });
+
+    it('should stringify non-string input', async () => {
+      context.input = { test: 123 };
+      const result = await plugin.execute(context);
+
+      expect(context.output).toBe('{"test":123}');
+      expect(result).toEqual({
+        processedAt: expect.any(Date),
+        inputLength: 12, // Length of stringified object
+        outputLength: 12,
+        processingTimeMs: expect.any(Number),
+      });
+    });
+
+    it('should handle empty input', async () => {
+      context.input = '';
+      const result = await plugin.execute(context);
+
+      expect(context.output).toBe('');
+      expect(result).toEqual({
+        processedAt: expect.any(Date),
+        inputLength: 0,
+        outputLength: 0,
+        processingTimeMs: expect.any(Number),
+      });
+    });
+  });
+
+  describe('after', () => {
+    it('should delete startTime from storage', async () => {
+      const deleteMock = vi.fn();
+      context.storage.delete = deleteMock;
+
+      await plugin.after(context);
+
+      expect(deleteMock).toHaveBeenCalledWith('startTime');
+    });
+  });
+
+  describe('summarize', () => {
+    it('should calculate correct summary metrics', async () => {
+      const metrics = [
+        {
+          processedAt: new Date(),
+          inputLength: 10,
+          outputLength: 15,
+          processingTimeMs: 100,
+        },
+        {
+          processedAt: new Date(),
+          inputLength: 20,
+          outputLength: 25,
+          processingTimeMs: 200,
+        },
+      ];
+
+      const summary = await plugin.summarize(metrics);
+
+      expect(summary).toEqual({
+        totalProcessed: 2,
+        averageProcessingTime: 150,
+        totalInputLength: 30,
+        totalOutputLength: 40,
+      });
+    });
+
+    it('should handle empty metrics array', async () => {
+      const summary = await plugin.summarize([]);
+
+      expect(summary).toEqual({
+        totalProcessed: 0,
+        averageProcessingTime: 0,
+        totalInputLength: 0,
+        totalOutputLength: 0,
+      });
+    });
+  });
+});

--- a/src/services/playground/__tests__/playground.test.ts
+++ b/src/services/playground/__tests__/playground.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PlaygroundService } from '../playground';
+import type { PlaygroundPlugin, PlaygroundContext } from '../types';
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock plugin for testing
+class MockPlugin implements PlaygroundPlugin {
+  name = 'mock';
+  enabled = true;
+  initialize = vi.fn();
+  before = vi.fn();
+  execute = vi.fn();
+  after = vi.fn();
+  summarize = vi.fn();
+}
+
+describe('PlaygroundService', () => {
+  let service: PlaygroundService;
+  let mockPlugin: MockPlugin;
+
+  beforeEach(() => {
+    mockPlugin = new MockPlugin();
+    service = new PlaygroundService({
+      plugins: [mockPlugin],
+      config: { debug: true },
+    });
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe('createJob', () => {
+    it('should create and start a job with correct initial state', async () => {
+      // Setup mock returns
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+      mockPlugin.summarize.mockResolvedValue({ total: 1 });
+
+      const config = { input: 'test' };
+      const job = await service.createJob(config);
+
+      expect(job.id).toBeDefined();
+      expect(job.config).toEqual(config);
+      expect(job.progress.status).toBe('completed');
+      expect(job.progress.completedPlugins).toContain('mock');
+      expect(job.retries).toBe(0);
+      expect(job.maxRetries).toBe(3);
+      expect(job.result).toBeDefined();
+      expect(job.result?.metrics).toHaveLength(1);
+      expect(job.result?.summary).toEqual({ mock: { total: 1 } });
+    });
+
+    it('should respect custom retries config and handle errors', async () => {
+      // Setup mock to throw error
+      const error = new Error('Plugin execution failed');
+      mockPlugin.execute.mockRejectedValue(error);
+
+      const config = { input: 'test', retries: 5 };
+      const job = await service.createJob(config);
+
+      expect(job.maxRetries).toBe(5);
+      expect(job.progress.status).toBe('completed');
+      expect(job.result?.error).toBeDefined();
+      expect(job.result?.error?.message).toBe('Plugin execution failed');
+      expect(job.result?.error?.plugin).toBe('mock');
+    });
+  });
+
+  describe('startJob', () => {
+    it('should run job through plugin lifecycle', async () => {
+      // Setup mock returns
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+      mockPlugin.summarize.mockResolvedValue({ total: 1 });
+
+      // Create job (which starts it automatically)
+      const job = await service.createJob({ input: 'test' });
+
+      // Verify plugin lifecycle
+      expect(mockPlugin.before).toHaveBeenCalled();
+      expect(mockPlugin.execute).toHaveBeenCalled();
+      expect(mockPlugin.after).toHaveBeenCalled();
+      expect(mockPlugin.summarize).toHaveBeenCalled();
+
+      // Verify job completion
+      expect(job.progress.status).toBe('completed');
+      expect(job.progress.completedPlugins).toContain('mock');
+      expect(job.result?.metrics).toHaveLength(1);
+      expect(job.result?.summary).toEqual({ mock: { total: 1 } });
+    });
+
+    it('should handle plugin execution error', async () => {
+      // Setup mock to throw error
+      const error = new Error('Plugin execution failed');
+      mockPlugin.execute.mockRejectedValue(error);
+
+      // Create job (which starts it automatically)
+      const result = await service.createJob({ input: 'test' });
+
+      // Verify error handling
+      expect(result.progress.status).toBe('completed');
+      expect(result.result?.error).toBeDefined();
+      expect(result.result?.error?.message).toBe('Plugin execution failed');
+      expect(result.result?.error?.plugin).toBe('mock');
+    });
+
+    it('should skip disabled plugins', async () => {
+      // Disable plugin
+      mockPlugin.enabled = false;
+
+      // Create job (which starts it automatically)
+      const job = await service.createJob({ input: 'test' });
+
+      // Verify plugin was not called
+      expect(mockPlugin.execute).not.toHaveBeenCalled();
+    });
+
+    it('should respect plugin filter in config', async () => {
+      // Create job with different plugin name (starts automatically)
+      const job = await service.createJob({
+        input: 'test',
+        plugins: ['other'],
+      });
+
+      // Verify plugin was not called
+      expect(mockPlugin.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getJob', () => {
+    it('should retrieve existing job', async () => {
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+      const job = await service.createJob({ input: 'test' });
+      const retrieved = await service.getJob(job.id);
+
+      expect(retrieved).toEqual(job);
+    });
+
+    it('should throw error for non-existent job', async () => {
+      await expect(service.getJob('non-existent')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('getProgress', () => {
+    it('should retrieve job progress', async () => {
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+      const job = await service.createJob({ input: 'test' });
+      const progress = await service.getProgress(job.id);
+
+      expect(progress).toEqual(job.progress);
+    });
+  });
+
+  describe('failJob', () => {
+    it('should properly mark job as failed', async () => {
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+      const job = await service.createJob({ input: 'test' });
+      const error = new Error('Test error');
+      const failed = await service.failJob(job.id, error);
+
+      expect(failed.progress.status).toBe('failed');
+      expect(failed.progress.error).toBe(error.message);
+      expect(failed.result?.error?.message).toBe(error.message);
+    });
+  });
+
+  describe('webhooks', () => {
+    const webhookUrl = 'https://example.com/webhook';
+    const webhookConfig = {
+      url: webhookUrl,
+      headers: { 'X-Custom-Header': 'test' },
+    };
+
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({ ok: true });
+      mockPlugin.execute.mockResolvedValue({ processed: true });
+    });
+
+    it('should send webhook on job start', async () => {
+      const job = await service.createJob({
+        input: 'test',
+        webhook: webhookConfig,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        webhookUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-Custom-Header': 'test',
+          }),
+          body: expect.stringContaining('"status":"started"'),
+        }),
+      );
+    });
+
+    it('should send webhook on job completion', async () => {
+      const job = await service.createJob({
+        input: 'test',
+        webhook: webhookConfig,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        webhookUrl,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"status":"completed"'),
+        }),
+      );
+    });
+
+    it('should send webhook on plugin events', async () => {
+      const job = await service.createJob({
+        input: 'test',
+        webhook: webhookConfig,
+      });
+
+      // Should have called for progress events
+      expect(mockFetch).toHaveBeenCalledWith(
+        webhookUrl,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"status":"progress"'),
+        }),
+      );
+    });
+
+    it('should respect event filter in webhook config', async () => {
+      const job = await service.createJob({
+        input: 'test',
+        webhook: {
+          ...webhookConfig,
+          on: ['started', 'completed'], // Only these events
+        },
+      });
+
+      // Should not have called for progress events
+      const calls = mockFetch.mock.calls;
+      const progressCalls = calls.filter(([_, options]) =>
+        options.body.includes('"status":"progress"'),
+      );
+      expect(progressCalls).toHaveLength(0);
+    });
+
+    it('should retry failed webhook calls', async () => {
+      // Mock first call to fail, second to succeed
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValue({ ok: true });
+
+      // Disable plugin to control webhook calls
+      mockPlugin.enabled = false;
+
+      const job = await service.createJob({
+        input: 'test',
+        webhook: webhookConfig,
+      });
+
+      // Should have been called for started event (fail + retry) only
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0][0]).toBe(webhookUrl);
+      expect(mockFetch.mock.calls[1][0]).toBe(webhookUrl);
+    });
+
+    it('should handle webhook errors gracefully', async () => {
+      // Mock all webhook calls to fail
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      // Disable plugin to control webhook calls
+      mockPlugin.enabled = false;
+
+      const job = await service.createJob({
+        input: 'test',
+        webhook: {
+          ...webhookConfig,
+          retries: 2, // Set retries to 2
+        },
+      });
+
+      // Should not throw error and job should complete
+      expect(job).toBeDefined();
+      // Should retry started event twice
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls.every(([url]) => url === webhookUrl)).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/services/playground/__tests__/playground.test.ts
+++ b/src/services/playground/__tests__/playground.test.ts
@@ -51,6 +51,23 @@ describe('PlaygroundService', () => {
       expect(job.result?.summary).toEqual({ mock: { total: 1 } });
     });
 
+    it('should return immediately for async jobs', async () => {
+      // Setup mock with delay
+      mockPlugin.execute.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return { processed: true };
+      });
+
+      const config = { input: 'test', async: true };
+      const job = await service.createJob(config);
+
+      // Should return before job completes
+      expect(job.id).toBeDefined();
+      expect(job.progress.status).toBe('running');
+      expect(job.progress.completedPlugins).toEqual([]);
+      expect(job.result?.metrics).toHaveLength(0);
+    });
+
     it('should respect custom retries config and handle errors', async () => {
       // Setup mock to throw error
       const error = new Error('Plugin execution failed');

--- a/src/services/playground/playground.ts
+++ b/src/services/playground/playground.ts
@@ -1,0 +1,400 @@
+import { EventEmitter } from 'events';
+import type {
+  PlaygroundJob,
+  PlaygroundConfig,
+  PlaygroundProgress,
+  PlaygroundResult,
+  PlaygroundPlugin,
+  PlaygroundContext,
+  PlaygroundEventMap,
+  PlaygroundServiceOptions,
+  PlaygroundStorage,
+  WebhookConfig,
+  WebhookEventType,
+} from './types';
+
+class MemoryStorage implements PlaygroundStorage {
+  private storage = new Map<string, any>();
+
+  async get<T>(key: string): Promise<T | null> {
+    return this.storage.get(key) || null;
+  }
+
+  async set<T>(key: string, value: T): Promise<void> {
+    this.storage.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.storage.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.storage.clear();
+  }
+}
+
+export class PlaygroundService extends EventEmitter {
+  private jobs: Map<string, PlaygroundJob> = new Map();
+  private plugins: Array<PlaygroundPlugin>;
+  private debug: boolean;
+
+  constructor(options: PlaygroundServiceOptions) {
+    super();
+    this.plugins = options.plugins;
+    this.debug = options.config?.debug ?? false;
+    this.initializePlugins();
+    this.setupWebhookHandlers();
+  }
+
+  // Type-safe event emitter methods
+  on<E extends keyof PlaygroundEventMap>(
+    event: E,
+    listener: (args: PlaygroundEventMap[E]) => void,
+  ): this {
+    return super.on(event, listener);
+  }
+
+  emit<E extends keyof PlaygroundEventMap>(
+    event: E,
+    args: PlaygroundEventMap[E],
+  ): boolean {
+    return super.emit(event, args);
+  }
+
+  private async initializePlugins(): Promise<void> {
+    for (const plugin of this.plugins) {
+      try {
+        if (plugin.initialize) {
+          await plugin.initialize();
+        }
+        // Initialize plugin storage if not provided
+        if (!plugin.storage) {
+          plugin.storage = new MemoryStorage();
+        }
+      } catch (error) {
+        console.error(`Failed to initialize plugin ${plugin.name}:`, error);
+      }
+    }
+  }
+
+  private createEmptyResult = (job: PlaygroundJob): PlaygroundResult => ({
+    config: job.config,
+    progress: job.progress,
+    metrics: [],
+  });
+
+  async createJob(config: PlaygroundConfig): Promise<PlaygroundJob> {
+    const id = crypto.randomUUID();
+    const now = new Date();
+
+    const job: PlaygroundJob = {
+      id,
+      config,
+      progress: {
+        status: 'queued',
+        startTime: now,
+        completedPlugins: [],
+      },
+      priority: 0,
+      retries: 0,
+      maxRetries: config.retries ?? 3,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.jobs.set(id, job);
+
+    // Start job immediately
+    return this.startJob(id);
+  }
+
+  async startJob(id: string): Promise<PlaygroundJob> {
+    const job = this.jobs.get(id);
+    if (!job) throw new Error(`Job ${id} not found`);
+
+    job.result = this.createEmptyResult(job);
+    job.progress = {
+      ...job.progress,
+      status: 'running',
+      startTime: new Date(),
+      completedPlugins: [],
+    };
+    job.updatedAt = new Date();
+
+    this.emit('jobStart', { jobId: id, job });
+
+    try {
+      // Create context
+      const context: PlaygroundContext = {
+        jobId: id,
+        input: job.config.input,
+        startTime: new Date(),
+        storage: new MemoryStorage(),
+      };
+
+      // Run enabled plugins in sequence
+      for (const plugin of this.plugins) {
+        if (!plugin.enabled) continue;
+        if (job.config.plugins && !job.config.plugins.includes(plugin.name))
+          continue;
+
+        try {
+          job.progress.currentPlugin = plugin.name;
+          this.emit('pluginStart', { jobId: id, pluginName: plugin.name, job });
+
+          // Run before hook
+          if (plugin.before) {
+            await plugin.before(context);
+          }
+
+          // Execute plugin
+          const metrics = await plugin.execute(context);
+
+          // Run after hook
+          if (plugin.after) {
+            await plugin.after(context);
+          }
+
+          // Store metrics
+          if (job.result) {
+            job.result.metrics.push({ [plugin.name]: metrics });
+          }
+
+          // Update progress
+          job.progress.completedPlugins.push(plugin.name);
+          this.emit('pluginComplete', {
+            jobId: id,
+            pluginName: plugin.name,
+            metrics,
+            job,
+          });
+        } catch (error) {
+          this.emit('pluginError', {
+            jobId: id,
+            pluginName: plugin.name,
+            error: error instanceof Error ? error : new Error(String(error)),
+            job,
+          });
+
+          // Store error and continue with next plugin
+          if (job.result) {
+            job.result.error = {
+              message: error instanceof Error ? error.message : String(error),
+              plugin: plugin.name,
+              timestamp: new Date(),
+            };
+          }
+        }
+      }
+
+      // Summarize results
+      if (job.result) {
+        const summaries = await Promise.all(
+          this.plugins
+            .filter((p) => p.enabled && p.summarize)
+            .map(async (plugin) => {
+              try {
+                const metrics = job
+                  .result!.metrics.map((m) => m[plugin.name])
+                  .filter(Boolean);
+                if (plugin.summarize) {
+                  return { [plugin.name]: await plugin.summarize(metrics) };
+                }
+              } catch (error) {
+                console.error(`Plugin ${plugin.name} summary failed:`, error);
+              }
+              return {};
+            }),
+        );
+
+        job.result.summary = Object.assign({}, ...summaries);
+      }
+
+      // Complete job
+      job.progress = {
+        ...job.progress,
+        status: 'completed',
+        endTime: new Date(),
+        currentPlugin: undefined,
+      };
+      job.updatedAt = new Date();
+
+      if (job.result) {
+        job.result.progress = { ...job.progress };
+      }
+
+      this.emit('jobComplete', { jobId: id, job });
+      this.jobs.set(id, job);
+      return job;
+    } catch (error) {
+      await this.failJob(
+        id,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      throw error;
+    }
+  }
+
+  async getJob(id: string): Promise<PlaygroundJob> {
+    const job = this.jobs.get(id);
+    if (!job) throw new Error(`Job ${id} not found`);
+    return job;
+  }
+
+  async getProgress(id: string): Promise<PlaygroundProgress> {
+    const job = await this.getJob(id);
+    return job.progress;
+  }
+
+  async failJob(id: string, error: Error): Promise<PlaygroundJob> {
+    const job = await this.getJob(id);
+    job.progress = {
+      ...job.progress,
+      status: 'failed',
+      endTime: new Date(),
+      error: error.message,
+    };
+    job.updatedAt = new Date();
+
+    // Create result if it doesn't exist
+    if (!job.result) {
+      job.result = this.createEmptyResult(job);
+    }
+
+    // Update result with error
+    job.result.progress = { ...job.progress };
+    job.result.error = {
+      message: error.message,
+      timestamp: new Date(),
+    };
+
+    this.emit('jobError', { jobId: id, error, job });
+    this.jobs.set(id, job);
+    return job;
+  }
+
+  private async sendWebhook(
+    event: WebhookEventType,
+    data: any,
+    config: WebhookConfig,
+  ): Promise<void> {
+    const maxRetries = config.retries ?? 3;
+    let retries = 0;
+
+    const sendAttempt = async () => {
+      try {
+        const response = await fetch(config.url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...config.headers,
+          },
+          body: JSON.stringify({
+            status: event,
+            jobId: data.jobId,
+            timestamp: new Date().toISOString(),
+            ...data,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return true;
+      } catch (error) {
+        return false;
+      }
+    };
+
+    while (retries < maxRetries) {
+      if (await sendAttempt()) return;
+      retries++;
+      if (retries < maxRetries) {
+        // Exponential backoff
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.pow(2, retries) * 1000),
+        );
+      } else {
+        console.error(
+          `Failed to send webhook for event ${event} after ${maxRetries} attempts`,
+        );
+      }
+    }
+  }
+
+  private shouldSendWebhook(
+    job: PlaygroundJob,
+    eventType: WebhookEventType,
+  ): boolean {
+    if (!job.config.webhook) return false;
+    if (!job.config.webhook.on) return true; // Send all events if not specified
+    return job.config.webhook.on.includes(eventType);
+  }
+
+  private setupWebhookHandlers(): void {
+    this.on('jobStart', async ({ jobId, job }) => {
+      if (this.shouldSendWebhook(job, 'started')) {
+        await this.sendWebhook(
+          'started',
+          {
+            jobId,
+            config: {
+              input: job.config.input,
+              plugins: job.config.plugins,
+            },
+          },
+          job.config.webhook!,
+        );
+      }
+    });
+
+    this.on('jobComplete', async ({ jobId, job }) => {
+      if (this.shouldSendWebhook(job, 'completed')) {
+        await this.sendWebhook(
+          'completed',
+          {
+            jobId,
+            result: job.result,
+            summary: {
+              duration: job.progress.endTime
+                ? new Date(job.progress.endTime).getTime() -
+                  new Date(job.progress.startTime).getTime()
+                : null,
+              completedPlugins: job.progress.completedPlugins,
+            },
+          },
+          job.config.webhook!,
+        );
+      }
+    });
+
+    this.on('jobError', async ({ jobId, job, error }) => {
+      if (this.shouldSendWebhook(job, 'failed')) {
+        await this.sendWebhook(
+          'failed',
+          {
+            jobId,
+            error: error.message,
+            progress: job.progress,
+          },
+          job.config.webhook!,
+        );
+      }
+    });
+
+    this.on('pluginComplete', async ({ jobId, job, pluginName, metrics }) => {
+      if (this.shouldSendWebhook(job, 'progress')) {
+        await this.sendWebhook(
+          'progress',
+          {
+            jobId,
+            pluginName,
+            metrics,
+            progress: job.progress,
+          },
+          job.config.webhook!,
+        );
+      }
+    });
+  }
+}

--- a/src/services/playground/playground.ts
+++ b/src/services/playground/playground.ts
@@ -104,8 +104,19 @@ export class PlaygroundService extends EventEmitter {
 
     this.jobs.set(id, job);
 
-    // Start job immediately
-    return this.startJob(id);
+    // Start job
+    if (config.async) {
+      // Start job in background
+      this.startJob(id).catch((error) => {
+        console.error(`Async job ${id} failed:`, error);
+      });
+
+      // Return job immediately
+      return job;
+    } else {
+      // Wait for job completion
+      return this.startJob(id);
+    }
   }
 
   async startJob(id: string): Promise<PlaygroundJob> {

--- a/src/services/playground/plugins/example-plugin.ts
+++ b/src/services/playground/plugins/example-plugin.ts
@@ -1,0 +1,80 @@
+import type { PlaygroundPlugin, PlaygroundContext } from '../types';
+
+interface ExampleMetric {
+  processedAt: Date;
+  inputLength: number;
+  outputLength: number;
+  processingTimeMs: number;
+}
+
+interface ExampleSummary {
+  totalProcessed: number;
+  averageProcessingTime: number;
+  totalInputLength: number;
+  totalOutputLength: number;
+}
+
+export class ExamplePlugin
+  implements PlaygroundPlugin<ExampleMetric, ExampleSummary>
+{
+  name = 'example';
+  enabled = true;
+
+  async initialize(): Promise<void> {
+    console.log('Example plugin initialized');
+  }
+
+  async before(context: PlaygroundContext): Promise<void> {
+    await context.storage.set('startTime', Date.now());
+    console.log('Example plugin before hook');
+  }
+
+  async execute(context: PlaygroundContext): Promise<ExampleMetric> {
+    const startTime =
+      (await context.storage.get<number>('startTime')) || Date.now();
+
+    // Simple example: reverse the input string if it's a string
+    const input = context.input;
+    const output =
+      typeof input === 'string'
+        ? input.split('').reverse().join('')
+        : JSON.stringify(input);
+
+    // Store the output
+    context.output = output;
+
+    const endTime = Date.now();
+
+    // Calculate lengths based on raw input/output
+    const inputLength =
+      typeof input === 'string' ? input.length : JSON.stringify(input).length;
+
+    return {
+      processedAt: new Date(),
+      inputLength,
+      outputLength: output.length,
+      processingTimeMs: endTime - startTime,
+    };
+  }
+
+  async after(context: PlaygroundContext): Promise<void> {
+    await context.storage.delete('startTime');
+    console.log('Example plugin after hook');
+  }
+
+  async summarize(metrics: ExampleMetric[]): Promise<ExampleSummary> {
+    const totalProcessed = metrics.length;
+    const totalProcessingTime = metrics.reduce(
+      (sum, m) => sum + m.processingTimeMs,
+      0,
+    );
+
+    return {
+      totalProcessed,
+      averageProcessingTime:
+        totalProcessed > 0 ? totalProcessingTime / totalProcessed : 0,
+      totalInputLength: metrics.reduce((sum, m) => sum + m.inputLength, 0),
+      totalOutputLength: metrics.reduce((sum, m) => sum + m.outputLength, 0),
+    };
+  }
+}

--- a/src/services/playground/types.ts
+++ b/src/services/playground/types.ts
@@ -41,6 +41,7 @@ export interface PlaygroundConfig {
   retries?: number;
   plugins?: string[];
   webhook?: WebhookConfig;
+  async?: boolean; // If true, don't wait for job completion before responding
 }
 
 export interface PlaygroundProgress {

--- a/src/services/playground/types.ts
+++ b/src/services/playground/types.ts
@@ -1,0 +1,103 @@
+import { EventEmitter } from 'events';
+
+export interface PlaygroundStorage {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export type WebhookEventType = 'started' | 'progress' | 'completed' | 'failed';
+
+export interface WebhookConfig {
+  url: string;
+  headers?: Record<string, string>;
+  retries?: number;
+  on?: WebhookEventType[]; // If not provided, will send all events
+}
+
+export interface PlaygroundPlugin<TMetric = any, TSummary = any> {
+  name: string;
+  enabled: boolean;
+  storage?: PlaygroundStorage;
+  initialize?(): Promise<void>;
+  before?(context: PlaygroundContext): Promise<void>;
+  execute(context: PlaygroundContext): Promise<TMetric>;
+  after?(context: PlaygroundContext): Promise<void>;
+  summarize?(metrics: TMetric[]): Promise<TSummary>;
+}
+
+export interface PlaygroundContext {
+  jobId: string;
+  input: any;
+  output?: any;
+  startTime: Date;
+  storage: PlaygroundStorage;
+  [key: string]: any;
+}
+
+export interface PlaygroundConfig {
+  input: any;
+  retries?: number;
+  plugins?: string[];
+  webhook?: WebhookConfig;
+}
+
+export interface PlaygroundProgress {
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  startTime: Date;
+  endTime?: Date;
+  error?: string;
+  currentPlugin?: string;
+  completedPlugins: string[];
+}
+
+export interface PlaygroundResult<TMetric = any, TSummary = any> {
+  config: PlaygroundConfig;
+  progress: PlaygroundProgress;
+  metrics: TMetric[];
+  summary?: TSummary;
+  error?: {
+    message: string;
+    plugin?: string;
+    timestamp: Date;
+  };
+}
+
+export interface PlaygroundJob<TMetric = any, TSummary = any> {
+  id: string;
+  config: PlaygroundConfig;
+  progress: PlaygroundProgress;
+  result?: PlaygroundResult<TMetric, TSummary>;
+  priority: number;
+  retries: number;
+  maxRetries: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PlaygroundServiceOptions {
+  plugins: Array<PlaygroundPlugin>;
+  config?: {
+    debug?: boolean;
+  };
+}
+
+export type PlaygroundEventMap = {
+  jobStart: { jobId: string; job: PlaygroundJob };
+  jobComplete: { jobId: string; job: PlaygroundJob };
+  jobError: { jobId: string; error: Error; job: PlaygroundJob };
+  pluginStart: { jobId: string; pluginName: string; job: PlaygroundJob };
+  pluginComplete: {
+    jobId: string;
+    pluginName: string;
+    metrics: any;
+    job: PlaygroundJob;
+  };
+  pluginError: {
+    jobId: string;
+    pluginName: string;
+    error: Error;
+    job: PlaygroundJob;
+  };
+};


### PR DESCRIPTION
Added the `Playground` service - Like the crawler, but handles arbitrary code instead of crawl jobs.

This is great for when you want to take your cloud automation 'off-platform' and perform some code locally, before sending it back - either using `async` flag to return as a webhook, or not, where we'll immediately return the result.